### PR TITLE
Coerce traits to String to fix issue #4

### DIFF
--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -5,6 +5,22 @@
 
 @implementation SEGFirebaseIntegration
 
+#pragma mark - Helper Functions
++ (NSDictionary *)mapToStrings:(NSDictionary *)dictionary
+{
+    NSMutableDictionary *mapped = [NSMutableDictionary dictionaryWithDictionary:dictionary];
+    
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+        id data = [mapped objectForKey:key];
+        if (![data isKindOfClass:[NSString class]]) {
+            [mapped setObject:[NSString stringWithFormat:@"%@", data] forKey:key];
+        }
+    }];
+    
+    return [mapped copy];
+}
+
+
 #pragma mark - Initialization
 
 - (id)initWithSettings:(NSDictionary *)settings
@@ -29,8 +45,9 @@
         [FIRAnalytics setUserID:payload.userId];
         SEGLog(@"[FIRAnalytics setUserId:%@]", payload.userId);
     }
-    
-    [payload.traits enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+    // Firebase requires user properties to be a NSString
+    NSDictionary *mappedTraits = [SEGFirebaseIntegration mapToStrings:payload.traits];
+    [mappedTraits enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop){
         NSString *trait = [key stringByReplacingOccurrencesOfString:@" " withString:@"_"];
         NSString *value = [obj stringByReplacingOccurrencesOfString:@" " withString:@"_"];
         [FIRAnalytics setUserPropertyString:value forName:trait];

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -8,15 +8,17 @@
 #pragma mark - Helper Functions
 + (NSDictionary *)mapToStrings:(NSDictionary *)dictionary
 {
-    NSMutableDictionary *mapped = [NSMutableDictionary dictionaryWithDictionary:dictionary];
+    NSMutableDictionary *output = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
     
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
-        if (![data isKindOfClass:[NSString class]]) {
-            [mapped setObject:[NSString stringWithFormat:@"%@", data] forKey:key];
+        if ([data isKindOfClass:[NSString class]]) {
+            [output setObject:data forKey:key];
+        } else {
+            [output setObject:[NSString stringWithFormat:@"%@", data] forKey:key];
         }
     }];
     
-    return [mapped copy];
+    return [output copy];
 }
 
 

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -10,8 +10,7 @@
 {
     NSMutableDictionary *mapped = [NSMutableDictionary dictionaryWithDictionary:dictionary];
     
-    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        id data = [mapped objectForKey:key];
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
         if (![data isKindOfClass:[NSString class]]) {
             [mapped setObject:[NSString stringWithFormat:@"%@", data] forKey:key];
         }

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -10,7 +10,7 @@
 {
     NSMutableDictionary *mapped = [NSMutableDictionary dictionaryWithDictionary:dictionary];
     
-    [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         id data = [mapped objectForKey:key];
         if (![data isKindOfClass:[NSString class]]) {
             [mapped setObject:[NSString stringWithFormat:@"%@", data] forKey:key];


### PR DESCRIPTION
Can confirm a crash will occur when passing in a non NSString value, due to `stringByReplacingOccurrencesOfString` assuming that all user traits passed on `identify` will be an NSString. 

For ex:

```
 [[SEGAnalytics sharedAnalytics] identify:@"432940" traits:@{
                                                                @"name":@"ladan",
                                                                @"gender":@"female",
                                                                @"age": @"28",
                                                                @"profession":@"software engineer",
                                                                @"favorite_food": @"hotdogs",
                                                                @"Height": @5,
                                                                @"favoriteFood": @"pizza"}];
```

Throws


> Segment-Firebase_Example[2735:2136898] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber stringByReplacingOccurrencesOfString:withString:]: unrecognized selector sent to instance 0xb000000000000052'


In addition to this, Firebase does not allow non NSStrings passed in. When enabling Firebase logging, Firebase logs
> Firebase_Example[12774] <Error> [Firebase/Analytics][I-ACS025003] User property must be NSString. Value: 45

Can confirm things populate as expected. After triggering the following `identify`:


```
    [[SEGAnalytics sharedAnalytics] identify:@"2993" traits:@{
                                                                @"name":@"Homer",
                                                                @"gender":@"male",
                                                                @"age": @45,
                                                                @"height": @6}];
```

I can see this populate in Firebase's **Streamview**:
![](http://g.recordit.co/46BkUH7Pw9.gif+)

Note that `height` is a custom trait which must be configured in Firebase's UI. `name`, `gender`, and `age` are reserved traits and do not need to be configured.

CC @tonyxiao for review
[JIRA](https://segment.atlassian.net/browse/PLATFORM-1229)