### PR TITLE
Refactor track util methods, update event mapping, format date

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -10,21 +10,491 @@
 
 SpecBegin(InitialSpecs)
 
-describe(@"these will pass", ^{ 
+describe(@"Firebase Integration", ^{
+    __block id mockFirebase;
+    __block SEGFirebaseIntegration *integration;
     
-    it(@"can do maths", ^{
-        expect(1).beLessThan(23);
+    beforeEach(^{
+        mockFirebase = mockClass([FIRAnalytics class]);
+        integration = [[SEGFirebaseIntegration alloc] initWithSettings:@{} andFirebase:mockFirebase];
     });
     
-    it(@"can read", ^{
-        expect(@"team").toNot.contain(@"I");
+    it(@"identify with no traits", ^{
+        SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"1111" anonymousId:nil traits:@{} context:@{} integrations:@{}];
+        
+        [integration identify:payload];
+        [verify(mockFirebase) setUserID:@"1111"];
+        
     });
     
-    it(@"will wait and succeed", ^{
-        waitUntil(^(DoneCallback done) {
-            done();
-        });
+    it(@"identify with traits", ^{
+        SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"7891" anonymousId:nil traits:@{
+                                                                                                                  @"name":@"Jerry Seinfield",
+                                                                                                                  @"gender":@"male",
+                                                                                                                  @"emotion":@"confused",
+                                                                                                                  @"age" :@47
+                                                                                                                  } context:@{} integrations:@{}];
+        [integration identify:payload];
+        [verify(mockFirebase) setUserID:@"7891"];
+        [verify(mockFirebase) setUserPropertyString:@"Jerry_Seinfield" forName: @"name"];
+        [verify(mockFirebase) setUserPropertyString:@"male" forName: @"gender"];
+        [verify(mockFirebase) setUserPropertyString:@"confused" forName: @"emotion"];
+        [verify(mockFirebase) setUserPropertyString:@"47" forName: @"age"];
+
+
     });
+    
+    it(@"track with no props", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Email Sent" properties:@{} context:@{} integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"Email_Sent" parameters:@{}];
+    });
+    
+    it(@"track with props", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Starship Ordered"
+                                                               properties:@{
+                                                                            @"Starship Type": @"Death Star"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"Starship_Ordered" parameters:@{
+                                                                                @"Starship_Type": @"Death Star"}];
+    });
+
+    it(@"track Order Completed", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
+                                                                                                          @"checkout_id":@"9bcf000000000000",
+                                                                                                          @"order_id":@"50314b8e",
+                                                                                                          @"affiliation":@"App Store",
+                                                                                                          @"total":@30.45,
+                                                                                                          @"shipping":@5.05,
+                                                                                                          @"tax":@1.20,
+                                                                                                          @"currency":@"USD",
+                                                                                                          @"category":@"Games",
+                                                                                                          @"revenue": @8,
+                                                                                                          @"products":@{
+                                                                                                                  @"product_id":@"2013294",
+                                                                                                                  @"category":@"Games",
+                                                                                                                  @"name":@"Monopoly: 3rd Edition",
+                                                                                                                  @"brand":@"Hasbros",
+                                                                                                                  @"price":@"21.99",
+                                                                                                                  @"quantity":@"1"
+                                                                                                                  }
+                                                                                                          }
+                                                                  context:@{} integrations:@{}];
+        
+        [integration track:payload];
+        // TODO: look into how to handle mapping Firebase reserved params to each products
+        [verify(mockFirebase) logEventWithName:@"ecommerce_purchase" parameters:@{
+                                                                                  @"checkout_id":@"9bcf000000000000",
+                                                                                  @"transaction_id":@"50314b8e",
+                                                                                  @"affiliation":@"App Store",
+                                                                                  @"value":@30.45,
+                                                                                  @"shipping":@5.05,
+                                                                                  @"tax":@1.20,
+                                                                                  @"currency":@"USD",
+                                                                                  @"item_category":@"Games",
+                                                                                  @"products":@{
+                                                                                          @"product_id":@"2013294",
+                                                                                          @"category":@"Games",
+                                                                                          @"name":@"Monopoly: 3rd Edition",
+                                                                                          @"brand":@"Hasbros",
+                                                                                          @"price":@"21.99",
+                                                                                          @"quantity":@"1"
+                                                                                          }
+                                                                                  }];
+    });
+    
+    it(@"track Product Clicked", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Clicked"
+                                                               properties:@{
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku":@"G-32",
+                                                                            @"category":@"Games",
+                                                                            @"name":@"Monopoly: 3rd Edition",
+                                                                            @"brand":@"Hasbro",
+                                                                            @"variant":@"200 pieces",
+                                                                            @"price":@18.99,
+                                                                            @"quantity":@1,
+                                                                            @"coupon":@"MAYDEALS",
+                                                                            @"position":@3,
+                                                                            @"url":@"https://www.company.com/product/path",
+                                                                            @"image_url":@"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"select_content" parameters:@{
+                                                                               @"item_id": @"507f1f77bcf86cd799439011",
+                                                                               @"sku":@"G-32",
+                                                                               @"item_category":@"Games",
+                                                                               @"item_name":@"Monopoly: 3rd Edition",
+                                                                               @"brand":@"Hasbro",
+                                                                               @"variant":@"200 pieces",
+                                                                               @"price":@18.99,
+                                                                               @"quantity":@1,
+                                                                               @"coupon":@"MAYDEALS",
+                                                                               @"position":@3,
+                                                                               @"url":@"https://www.company.com/product/path",
+                                                                               @"image_url":@"https://www.company.com/product/path.jpg"}];
+    });
+    
+    it(@"track Product Viewed", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Viewed"
+                                                               properties:@{
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku":@"G-32",
+                                                                            @"category":@"Games",
+                                                                            @"name":@"Monopoly 3rd Edition",
+                                                                            @"brand":@"Hasbro",
+                                                                            @"variant":@"200 pieces",
+                                                                            @"price":@18.99,
+                                                                            @"quantity":@1,
+                                                                            @"coupon":@"MAYDEALS",
+                                                                            @"currency":@"usd",
+                                                                            @"position":@3,
+                                                                            @"url":@"https://www.company.com/product/path",
+                                                                            @"image_url":@"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"view_item" parameters:@{
+                                                                              @"item_id": @"507f1f77bcf86cd799439011",
+                                                                              @"sku":@"G-32",
+                                                                              @"item_category":@"Games",
+                                                                              @"item_name":@"Monopoly 3rd Edition",
+                                                                              @"brand":@"Hasbro",
+                                                                              @"variant":@"200 pieces",
+                                                                              @"price":@18.99,
+                                                                              @"quantity":@1,
+                                                                              @"coupon":@"MAYDEALS",
+                                                                              @"currency":@"usd",
+                                                                              @"position":@3,
+                                                                              @"url":@"https://www.company.com/product/path",
+                                                                              @"image_url":@"https://www.company.com/product/path.jpg"}];
+    });
+
+    it(@"track Product Added", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Added"
+                                                               properties:@{
+                                                                            @"cart_id":@"skdjsidjsdkdj29j",
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku":@"G-32",
+                                                                            @"category":@"Games",
+                                                                            @"name":@"Monopoly: 3rd Edition",
+                                                                            @"brand":@"Hasbro",
+                                                                            @"variant":@"200 pieces",
+                                                                            @"price":@18.99,
+                                                                            @"quantity":@1,
+                                                                            @"coupon":@"MAYDEALS",
+                                                                            @"position":@3,
+                                                                            @"url":@"https://www.company.com/product/path",
+                                                                            @"image_url":@"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"add_to_cart" parameters:@{
+                                                                           @"cart_id":@"skdjsidjsdkdj29j",
+                                                                           @"item_id": @"507f1f77bcf86cd799439011",
+                                                                           @"sku":@"G-32",
+                                                                           @"item_category":@"Games",
+                                                                           @"item_name":@"Monopoly: 3rd Edition",
+                                                                           @"brand":@"Hasbro",
+                                                                           @"variant":@"200 pieces",
+                                                                           @"price":@18.99,
+                                                                           @"quantity":@1,
+                                                                           @"coupon":@"MAYDEALS",
+                                                                           @"position":@3,
+                                                                           @"url":@"https://www.company.com/product/path",
+                                                                           @"image_url":@"https://www.company.com/product/path.jpg"}];
+    });
+    
+    it(@"track Product Removed", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Removed"
+                                                               properties:@{
+                                                                            @"cart_id":@"ksjdj92dj29dj92d2j",
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku":@"G-32",
+                                                                            @"category":@"Games",
+                                                                            @"name":@"Monopoly: 3rd Edition",
+                                                                            @"brand":@"Hasbro",
+                                                                            @"variant":@"200 pieces",
+                                                                            @"price":@18.99,
+                                                                            @"quantity":@1,
+                                                                            @"coupon":@"MAYDEALS",
+                                                                            @"position":@3,
+                                                                            @"url":@"https://www.company.com/product/path",
+                                                                            @"image_url":@"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"remove_from_cart" parameters:@{
+                                                                                @"cart_id":@"ksjdj92dj29dj92d2j",
+                                                                                @"item_id": @"507f1f77bcf86cd799439011",
+                                                                                @"sku":@"G-32",
+                                                                                @"item_category":@"Games",
+                                                                                @"item_name":@"Monopoly: 3rd Edition",
+                                                                                @"brand":@"Hasbro",
+                                                                                @"variant":@"200 pieces",
+                                                                                @"price":@18.99,
+                                                                                @"quantity":@1,
+                                                                                @"coupon":@"MAYDEALS",
+                                                                                @"position":@3,
+                                                                                @"url":@"https://www.company.com/product/path",
+                                                                                @"image_url":@"https://www.company.com/product/path.jpg"}];
+    });
+    
+    it(@"track Checkout Started", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Checkout Started"
+                                                               properties:@{
+                                                                            @"checkout_id":@"9bcf000000000000",
+                                    @"order_id":@"50314b8e",
+                                    @"affiliation":@"App Store",
+                                    @"total":@30.45,
+                                    @"shipping":@5.05,
+                                    @"tax":@1.20,
+                                    @"currency":@"USD",
+                                    @"category":@"Games",
+                                    @"revenue": @8,
+                                    @"products":@{
+                                                  @"product_id":@"2013294",
+                                                  @"category":@"Games",
+                                                  @"name":@"Monopoly: 3rd Edition",
+                                                  @"brand":@"Hasbros",
+                                                  @"price":@"21.99",
+                                                  @"quantity":@"1"
+                                                  }
+                                    }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"begin_checkout" parameters:@{
+                                                                                @"checkout_id":@"9bcf000000000000",
+                                                                                @"transaction_id":@"50314b8e",
+                                                                                @"affiliation":@"App Store",
+                                                                                @"value":@30.45,
+                                                                                @"shipping":@5.05,
+                                                                                @"tax":@1.20,
+                                                                                @"currency":@"USD",
+                                                                                @"item_category":@"Games",
+                                                                                @"products":@{
+                                                                                        @"product_id":@"2013294",
+                                                                                        @"category":@"Games",
+                                                                                        @"name":@"Monopoly: 3rd Edition",
+                                                                                        @"brand":@"Hasbros",
+                                                                                        @"price":@"21.99",
+                                                                                        @"quantity":@"1"
+                                                                                        }
+                                                                                }];
+    });
+    
+    it(@"track Payment Info Entered", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Payment Info Entered"
+                                                               properties:@{
+                                                                            @"checkout_id": @"39f39fj39f3jf93fj9fj39fj3f",
+                                                                            @"order_id":@"dkfsjidfjsdifsdfksdjfkdsfjsdfkdsf",
+                                                                            @"step":@"Payment",
+                                                                            @"shipping_method":@"ground",
+                                                                            @"payment_method":@"credit card"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"add_payment_info" parameters:@{
+                                                                                @"checkout_id": @"39f39fj39f3jf93fj9fj39fj3f",
+                                                                                @"transaction_id":@"dkfsjidfjsdifsdfksdjfkdsfjsdfkdsf",
+                                                                                @"step":@"Payment",
+                                                                                @"shipping_method":@"ground",
+                                                                                @"payment_method":@"credit card"}];
+    });
+    
+    it(@"track Order Refunded", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Refunded"
+                                                               properties:@{
+                                                                            @"order_id": @"50314b8e9bcf000000000000"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"purchase_refund" parameters:@{
+                                                                                @"transaction_id": @"50314b8e9bcf000000000000"}];
+    });
+    
+    
+    it(@"track Product List Viewed", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product List Viewed"
+                                                               properties:@{
+                                                                            @"list_id": @"hot_deals_1",
+                                                                            @"category":@"Deals",
+                                                                            @"products":@{
+                                                                                    @"product_id":@"2013294",
+                                                                                    @"category":@"Games",
+                                                                                    @"name":@"Monopoly: 3rd Edition",
+                                                                                    @"brand":@"Hasbros",
+                                                                                    @"price":@"21.99",
+                                                                                    @"quantity":@"1"
+                                                                                    }
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"view_item_list" parameters:@{
+                                                                              @"list_id": @"hot_deals_1",
+                                                                              @"item_category":@"Deals",
+                                                                              @"products":@{
+                                                                                      @"product_id":@"2013294",
+                                                                                      @"category":@"Games",
+                                                                                      @"name":@"Monopoly: 3rd Edition",
+                                                                                      @"brand":@"Hasbros",
+                                                                                      @"price":@"21.99",
+                                                                                      @"quantity":@"1"
+                                                                                      }
+                                                                              }];
+    });
+    
+    
+    
+    it(@"track Product Added to Wishlist", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Added to Wishlist"
+                                                               properties:@{
+                                                                            @"wishlist_id": @"skdjsidjsdkdj29j",
+                                                                            @"wishlist_name": @"Loved Games",
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku": @"G-32",
+                                                                            @"category": @"Games",
+                                                                            @"name": @"Monopoly: 3rd Edition",
+                                                                            @"brand": @"Hasbro",
+                                                                            @"variant": @"200 pieces",
+                                                                            @"price": @18.99,
+                                                                            @"quantity": @1,
+                                                                            @"coupon": @"MAYDEALS",
+                                                                            @"position": @3,
+                                                                            @"url": @"https://www.company.com/product/path",
+                                                                            @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"add_to_wishlist" parameters:@{
+                                                                               @"wishlist_id": @"skdjsidjsdkdj29j",
+                                                                               @"wishlist_name": @"Loved Games",
+                                                                               @"item_id": @"507f1f77bcf86cd799439011",
+                                                                               @"sku": @"G-32",
+                                                                               @"item_category": @"Games",
+                                                                               @"item_name": @"Monopoly: 3rd Edition",
+                                                                               @"brand": @"Hasbro",
+                                                                               @"variant": @"200 pieces",
+                                                                               @"price": @18.99,
+                                                                               @"quantity": @1,
+                                                                               @"coupon": @"MAYDEALS",
+                                                                               @"position": @3,
+                                                                               @"url": @"https://www.company.com/product/path",
+                                                                               @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                               }];
+    });
+    
+    
+    it(@"track Product Shared", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Product Shared"
+                                                               properties:@{
+                                                                            @"share_via": @"email",
+                                                                            @"share_message": @"Hey, check out this item",
+                                                                            @"recipient": @"friend@gmail.com",
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku": @"G-32",
+                                                                            @"category": @"Games",
+                                                                            @"name": @"Monopoly: 3rd Edition",
+                                                                            @"brand": @"Hasbro",
+                                                                            @"variant": @"200 pieces",
+                                                                            @"price": @18.99,
+                                                                            @"url": @"https://www.company.com/product/path",
+                                                                            @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"share" parameters:@{
+                                                                                @"share_via": @"email",
+                                                                                @"share_message": @"Hey, check out this item",
+                                                                                @"recipient": @"friend@gmail.com",
+                                                                                @"item_id": @"507f1f77bcf86cd799439011",
+                                                                                @"sku": @"G-32",
+                                                                                @"item_category": @"Games",
+                                                                                @"item_name": @"Monopoly: 3rd Edition",
+                                                                                @"brand": @"Hasbro",
+                                                                                @"variant": @"200 pieces",
+                                                                                @"price": @18.99,
+                                                                                @"url": @"https://www.company.com/product/path",
+                                                                                @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                                }];
+    });
+    
+    it(@"track Cart Shared", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Cart Shared"
+                                                               properties:@{
+                                                                            @"share_via": @"email",
+                                                                            @"share_message": @"Hey, check out this item",
+                                                                            @"recipient": @"friend@gmail.com",
+                                                                            @"product_id": @"507f1f77bcf86cd799439011",
+                                                                            @"sku": @"G-32",
+                                                                            @"category": @"Games",
+                                                                            @"name": @"Monopoly: 3rd Edition",
+                                                                            @"brand": @"Hasbro",
+                                                                            @"variant": @"200 pieces",
+                                                                            @"price": @18.99,
+                                                                            @"url": @"https://www.company.com/product/path",
+                                                                            @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"share" parameters:@{
+                                                                     @"share_via": @"email",
+                                                                     @"share_message": @"Hey, check out this item",
+                                                                     @"recipient": @"friend@gmail.com",
+                                                                     @"item_id": @"507f1f77bcf86cd799439011",
+                                                                     @"sku": @"G-32",
+                                                                     @"item_category": @"Games",
+                                                                     @"item_name": @"Monopoly: 3rd Edition",
+                                                                     @"brand": @"Hasbro",
+                                                                     @"variant": @"200 pieces",
+                                                                     @"price": @18.99,
+                                                                     @"url": @"https://www.company.com/product/path",
+                                                                     @"image_url": @"https://www.company.com/product/path.jpg"
+                                                                     }];
+    });
+    
+    it(@"track Products Searched", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Products Searched"
+                                                               properties:@{
+                                                                            @"query": @"blue hotpants"
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}];
+        
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"search" parameters:@{
+                                                                      @"search_term": @"blue hotpants"
+                                                                      }];
+    });
+    
 });
 
 SpecEnd

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -165,19 +165,19 @@ describe(@"Firebase Integration", ^{
         
         [integration track:payload];
         [verify(mockFirebase) logEventWithName:@"view_item" parameters:@{
-                                                                              @"item_id": @"507f1f77bcf86cd799439011",
-                                                                              @"sku":@"G-32",
-                                                                              @"item_category":@"Games",
-                                                                              @"item_name":@"Monopoly 3rd Edition",
-                                                                              @"brand":@"Hasbro",
-                                                                              @"variant":@"200 pieces",
-                                                                              @"price":@18.99,
-                                                                              @"quantity":@1,
-                                                                              @"coupon":@"MAYDEALS",
-                                                                              @"currency":@"usd",
-                                                                              @"position":@3,
-                                                                              @"url":@"https://www.company.com/product/path",
-                                                                              @"image_url":@"https://www.company.com/product/path.jpg"}];
+                                                                         @"item_id": @"507f1f77bcf86cd799439011",
+                                                                         @"sku":@"G-32",
+                                                                         @"item_category":@"Games",
+                                                                         @"item_name":@"Monopoly 3rd Edition",
+                                                                         @"brand":@"Hasbro",
+                                                                         @"variant":@"200 pieces",
+                                                                         @"price":@18.99,
+                                                                         @"quantity":@1,
+                                                                         @"coupon":@"MAYDEALS",
+                                                                         @"currency":@"usd",
+                                                                         @"position":@3,
+                                                                         @"url":@"https://www.company.com/product/path",
+                                                                         @"image_url":@"https://www.company.com/product/path.jpg"}];
     });
 
     it(@"track Product Added", ^{
@@ -258,23 +258,23 @@ describe(@"Firebase Integration", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Checkout Started"
                                                                properties:@{
                                                                             @"checkout_id":@"9bcf000000000000",
-                                    @"order_id":@"50314b8e",
-                                    @"affiliation":@"App Store",
-                                    @"total":@30.45,
-                                    @"shipping":@5.05,
-                                    @"tax":@1.20,
-                                    @"currency":@"USD",
-                                    @"category":@"Games",
-                                    @"revenue": @8,
-                                    @"products":@{
-                                                  @"product_id":@"2013294",
-                                                  @"category":@"Games",
-                                                  @"name":@"Monopoly: 3rd Edition",
-                                                  @"brand":@"Hasbros",
-                                                  @"price":@"21.99",
-                                                  @"quantity":@"1"
-                                                  }
-                                    }
+                                                                            @"order_id":@"50314b8e",
+                                                                            @"affiliation":@"App Store",
+                                                                            @"total":@30.45,
+                                                                            @"shipping":@5.05,
+                                                                            @"tax":@1.20,
+                                                                            @"currency":@"USD",
+                                                                            @"category":@"Games",
+                                                                            @"revenue": @8,
+                                                                            @"products":@{
+                                                                                    @"product_id":@"2013294",
+                                                                                    @"category":@"Games",
+                                                                                    @"name":@"Monopoly: 3rd Edition",
+                                                                                    @"brand":@"Hasbros",
+                                                                                    @"price":@"21.99",
+                                                                                    @"quantity":@"1"
+                                                                                    }
+                                                                            }
                                                                   context:@{}
                                                              integrations:@{}];
         

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.h
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.h
@@ -6,11 +6,13 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegration.h>
 
-
 @interface SEGFirebaseIntegration : NSObject <SEGIntegration>
 
 @property (nonatomic, strong) NSDictionary *settings;
+@property (nonatomic, strong) Class firebaseClass;
 
 - (id)initWithSettings:(NSDictionary *)settings;
+- (id)initWithSettings:(NSDictionary *)settings andFirebase:(id)firebaseClass;
+
 
 @end

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -96,18 +96,18 @@
 - (NSDictionary *)returnMappedFirebaseParameters:(NSDictionary *)properties
 {
     NSDictionary *map = [NSDictionary dictionaryWithObjectsAndKeys:
-                        @"category", kFIRParameterItemCategory,
-                        @"product_id", kFIRParameterItemID,
-                        @"name", kFIRParameterItemName,
-                        @"price", kFIRParameterPrice,
-                        @"quantity", kFIRParameterQuantity,
-                        @"query", kFIRParameterSearchTerm,
-                        @"shipping", kFIRParameterShipping,
-                        @"tax", kFIRParameterTax,
-                        @"total", kFIRParameterValue,
-                        @"revenue", kFIRParameterValue,
-                        @"order_id", kFIRParameterTransactionID,
-                        @"currency", kFIRParameterCurrency, nil];
+                        kFIRParameterItemCategory, @"category",
+                        kFIRParameterItemID, @"product_id",
+                        kFIRParameterItemName, @"name",
+                        kFIRParameterPrice, @"price",
+                        kFIRParameterQuantity, @"quantity",
+                        kFIRParameterSearchTerm, @"query",
+                        kFIRParameterShipping, @"shipping",
+                        kFIRParameterTax, @"tax",
+                        kFIRParameterValue, @"total",
+                        kFIRParameterValue, @"revenue",
+                        kFIRParameterTransactionID, @"order_id",
+                        kFIRParameterCurrency, @"currency", nil];
     
     
     return [SEGFirebaseIntegration mapToFirebaseParameters:properties withMap:map];
@@ -115,16 +115,16 @@
 
 + (NSDictionary *)mapToFirebaseParameters:(NSDictionary *)properties withMap:(NSDictionary *)mapper
 {
-    NSMutableDictionary *mappedParams = [NSMutableDictionary dictionaryWithCapacity:properties.count];
+    NSMutableDictionary *mappedParams = [NSMutableDictionary dictionaryWithDictionary:properties];
     [mapper enumerateKeysAndObjectsUsingBlock:^(NSString *original, NSString *new, BOOL *stop) {
         id data = [properties objectForKey:original];
         if (properties[original] && data) {
+            [mappedParams removeObjectForKey:original];
             [mappedParams setObject:data forKey:new];
-        } else {
-            [mappedParams addEntriesFromDictionary:formatEventProperties(properties)];
         }
     }];
     
+    [mappedParams addEntriesFromDictionary:formatEventProperties(mappedParams)];
     return [mappedParams copy];
 }
 
@@ -135,6 +135,9 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
         if ([data isKindOfClass:[NSString class]]) {
             data = [SEGFirebaseIntegration checkForDate:data];
             data = [data stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+            [output setObject:data forKey:key];
+        } else if ([data isKindOfClass:[NSNumber class]]){
+            data = [NSNumber numberWithDouble:[data doubleValue]];
             [output setObject:data forKey:key];
         } else {
             [output setObject:data forKey:key];

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -174,7 +174,6 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
         NSDateFormatter *firebaseFormat = [[NSDateFormatter alloc] init];
         [firebaseFormat setDateFormat:@"yyyy-MM-dd"];
         NSString *output = [firebaseFormat stringFromDate:date];
-        SEGLog(@"output", output);
         return output;
     }
  

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -11,6 +11,7 @@
 {
     if (self = [super init]) {
         self.settings = settings;
+
         NSString *deepLinkURLScheme = [self.settings objectForKey:@"deepLinkURLScheme"];
         if (deepLinkURLScheme) {
             [FIROptions defaultOptions].deepLinkURLScheme = deepLinkURLScheme;
@@ -133,7 +134,6 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
     NSMutableDictionary *output = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
         if ([data isKindOfClass:[NSString class]]) {
-            data = [SEGFirebaseIntegration checkForDate:data];
             data = [data stringByReplacingOccurrencesOfString:@" " withString:@"_"];
             [output setObject:data forKey:key];
         } else if ([data isKindOfClass:[NSNumber class]]){
@@ -155,7 +155,6 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
     
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
         if ([data isKindOfClass:[NSString class]]) {
-            [SEGFirebaseIntegration checkForDate:data];
             [output setObject:data forKey:key];
         } else {
             [output setObject:[NSString stringWithFormat:@"%@", data] forKey:key];
@@ -165,21 +164,5 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
     return [output copy];
 }
 
-// Firebase requires dates to be formatted as YYYY-MM-DD
-+ (NSString *)checkForDate:(NSString *)input
-{
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    NSDate *date = [dateFormatter dateFromString:input];
-    if (date == nil) {
-        return input;
-    } else {
-        NSDateFormatter *firebaseFormat = [[NSDateFormatter alloc] init];
-        [firebaseFormat setDateFormat:@"yyyy-MM-dd"];
-        NSString *output = [firebaseFormat stringFromDate:date];
-        return output;
-    }
- 
-}
 
 @end


### PR DESCRIPTION
We were incorrectly mapping Firebase events and params, reference [here](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#/c:FIRParameterNames.h@kFIRParameterCampaign). 

Also removed logic to handle checking for a number value within an NSString, as Firebase does not document the need to handle that. 

Firebase required dates be formatted as YYYY-MM-DD. The logic checks an iso8601 NSString because [analytics-ios will convert NSDate time to an iso8601 formatted string](https://github.com/segmentio/analytics-ios/blob/a0a44a8c00ea941d6214123b290c6338fc432c18/Analytics/Classes/Internal/SEGAnalyticsUtils.m#L15).