### PR TITLE
Formats trait values to trim spaces instead of replacing them with underscore

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -36,7 +36,7 @@ describe(@"Firebase Integration", ^{
                                                                                                                   } context:@{} integrations:@{}];
         [integration identify:payload];
         [verify(mockFirebase) setUserID:@"7891"];
-        [verify(mockFirebase) setUserPropertyString:@"Jerry_Seinfield" forName: @"name"];
+        [verify(mockFirebase) setUserPropertyString:@"Jerry Seinfield" forName: @"name"];
         [verify(mockFirebase) setUserPropertyString:@"male" forName: @"gender"];
         [verify(mockFirebase) setUserPropertyString:@"confused" forName: @"emotion"];
         [verify(mockFirebase) setUserPropertyString:@"47" forName: @"age"];

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -42,7 +42,7 @@
     NSDictionary *mappedTraits = [SEGFirebaseIntegration mapToStrings:payload.traits];
     [mappedTraits enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop){
         NSString *trait = [key stringByReplacingOccurrencesOfString:@" " withString:@"_"];
-        NSString *value = [obj stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+        NSString *value = [obj stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         [self.firebaseClass setUserPropertyString:value forName:trait];
         SEGLog(@"[FIRAnalytics setUserPropertyString:%@ forName:%@]", value, trait);
     }];


### PR DESCRIPTION
I found it quite odd behaviour to format values such that spaces are replaced with underscore. 
If I were to send the name of the user or similar I would have the following as the value: 'Cem_Turan' instead of 'Cem Turan'.

This PR changes the behaviour such that surrounding whitespaces and new lines are trimmed.