### PR TITLE
Adds subspec workaround.

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,6 @@
+## Without use_frameworks!
 target 'Segment-Firebase_Example' do
+  # Use default subspec
   pod 'Segment-Firebase', :path => '../'
   
   target 'Segment-Firebase_Tests' do
@@ -9,3 +11,23 @@ target 'Segment-Firebase_Example' do
     pod 'Expecta'
   end
 end
+
+
+## With use_frameworks!
+# Use only 'Segment-Firebase/StaticLibWorkaround'
+
+#use_frameworks!
+#
+#target 'Segment-Firebase_Example' do
+#    pod 'Segment-Firebase/StaticLibWorkaround', :path => '../'
+#    pod 'Firebase'
+#
+#end
+#
+#target 'Segment-Firebase_Tests' do
+#    inherit! :search_paths
+#
+#    pod 'Specta'
+#    pod 'Expecta'
+#    pod 'OCMockito'
+#end

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 7"
 PROJECT := Segment-Firebase
 XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -33,4 +33,14 @@ Pod::Spec.new do |s|
     # This will bundle in Firebase Dynamic Link support
     dynamiclinks.dependency 'Firebase/DynamicLinks', '~> 4.0'
   end
+
+
+  s.subspec 'StaticLibWorkaround' do |workaround|
+    # For users who are unable to bundle static libraries as dependencies
+    # you can choose this subspec, but be sure to include the folling in your podfile
+    # pod 'Firebase'
+    # Please manually add the following file preserved by Cocoapods to your xcodeproj file
+    workaround.preserve_paths = 'Pod/Classes/**/*'
+  end
+
 end

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
     # you can choose this subspec, but be sure to include the folling in your podfile
     # pod 'Firebase'
     # Please manually add the following file preserved by Cocoapods to your xcodeproj file
-    workaround.preserve_paths = 'Pod/Classes/**/*'
+    workaround.preserve_paths = 'Segment-Firebase/Classes/**/*'
   end
 
 end


### PR DESCRIPTION
This workaround to Cocoapods [Static Library/Framework](https://github.com/CocoaPods/CocoaPods/issues/2926).

The limitation occurs when an application is built in Swift, you are including `use_frameworks!` in your podfile, and are using a transitive dependency that is provided as a static library or framework.

The current workaround (as outlined in this subspec) is to copy the integration code manually into your project, then depend on Firebase directly. Instead of importing the integration from our library you would import the integration from your local copy. This eliminates the transitive dependency from the App -> Segment-Firebase -> Firebase to App -> Firebase.

Tested with the following configurations

Without `use_frameworks!`
- Use default subspec

With `use_frameworks!`
- Use only Segment-Firebase/StaticLibWorkaround

CC @TeresaNesteby 