### PR TITLE
Upgrade from Firebase 4 to Firebase 5 to support Crashlytics

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,22 +1,50 @@
 PODS:
-  - Analytics (3.6.7)
+  - Analytics (3.6.9)
   - Expecta (1.0.6)
-  - Firebase/Core (4.1.1):
-    - FirebaseAnalytics (= 4.0.3)
-    - FirebaseCore (= 4.0.6)
-  - FirebaseAnalytics (4.0.3):
-    - FirebaseCore (~> 4.0)
-    - FirebaseInstanceID (~> 2.0)
-    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
+  - Firebase/Core (5.9.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 5.2.0)
+  - Firebase/CoreOnly (5.9.0):
+    - FirebaseCore (= 5.1.4)
+  - FirebaseAnalytics (5.2.0):
+    - FirebaseCore (~> 5.1)
+    - FirebaseInstanceID (~> 3.2)
+    - GoogleAppMeasurement (~> 5.2)
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
+    - GoogleUtilities/Network (~> 5.2)
+    - "GoogleUtilities/NSData+zlib (~> 5.2)"
     - nanopb (~> 0.3)
-  - FirebaseCore (4.0.6):
-    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
+  - FirebaseCore (5.1.4):
+    - GoogleUtilities/Logger (~> 5.2)
+  - FirebaseInstanceID (3.2.2):
+    - FirebaseCore (~> 5.1)
+    - GoogleUtilities/Environment (~> 5.3)
+    - GoogleUtilities/UserDefaults (~> 5.3)
+  - GoogleAppMeasurement (5.2.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
+    - GoogleUtilities/Network (~> 5.2)
+    - "GoogleUtilities/NSData+zlib (~> 5.2)"
     - nanopb (~> 0.3)
-  - FirebaseInstanceID (2.0.2):
-    - FirebaseCore (~> 4.0)
-  - GoogleToolboxForMac/Defines (2.1.1)
-  - "GoogleToolboxForMac/NSData+zlib (2.1.1)":
-    - GoogleToolboxForMac/Defines (= 2.1.1)
+  - GoogleUtilities/AppDelegateSwizzler (5.3.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (5.3.0)
+  - GoogleUtilities/Logger (5.3.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (5.3.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (5.3.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (5.3.0)"
+  - GoogleUtilities/Reachability (5.3.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (5.3.0):
+    - GoogleUtilities/Logger
   - nanopb (0.3.8):
     - nanopb/decode (= 0.3.8)
     - nanopb/encode (= 0.3.8)
@@ -27,12 +55,12 @@ PODS:
     - OCHamcrest (~> 7.0)
   - Segment-Firebase (2.3.0):
     - Analytics (~> 3.2)
-    - Firebase/Core (~> 4.0)
+    - Firebase/Core (~> 5.0)
     - Segment-Firebase/Core (= 2.3.0)
   - Segment-Firebase/Core (2.3.0):
     - Analytics (~> 3.2)
-    - Firebase/Core (~> 4.0)
-  - Specta (1.0.6)
+    - Firebase/Core (~> 5.0)
+  - Specta (1.0.7)
 
 DEPENDENCIES:
   - Expecta
@@ -48,7 +76,8 @@ SPEC REPOS:
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseInstanceID
-    - GoogleToolboxForMac
+    - GoogleAppMeasurement
+    - GoogleUtilities
     - nanopb
     - OCHamcrest
     - OCMockito
@@ -59,18 +88,19 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: 2c09a50e3478a3a7ced08a22d00c43ba6f7011e6
+  Analytics: 6541ce337e99d9f7a2240a8b3953940a7be5f998
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  Firebase: 052c0de688fc87b414996eea13e223dd9fee3fa2
-  FirebaseAnalytics: 76f754d37ca5b04f36856729b6af3ca0152d1069
-  FirebaseCore: 28def3c643989c97ea5a69ea5000f5fa9902b9fd
-  FirebaseInstanceID: c4c7fca62c7b7330caee5da04f19a37ea37bb1c1
-  GoogleToolboxForMac: 8e329f1b599f2512c6b10676d45736bcc2cbbeb0
+  Firebase: 383fa29aca93e371cab776b48a5c66544d3c2003
+  FirebaseAnalytics: 831f1f127f4a75698e9875a87bf7e2668730d953
+  FirebaseCore: 2a84b6b325792a4319ef71ee18819dcba08d2fd7
+  FirebaseInstanceID: 78ba376fcd5b94c001f9999b2cbd3d1f1e56e78d
+  GoogleAppMeasurement: 2b3a023a61239c8d002e6e4fcf4abce8eddce0e0
+  GoogleUtilities: 760ccb53b7c7f40f9c02d8c241f76f841a7a6162
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   OCHamcrest: 7c2229e7ea96eecd6e43dbef7c68e1dfbd6928b8
   OCMockito: 2598f5d43f6e74964d3ec3b9dea8b4fde3ea2c43
-  Segment-Firebase: 2162b59b4b9b9dc7b5505bb538f309334a5a6895
-  Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
+  Segment-Firebase: 804d7e63849ad42cc44dcbdb91ad080fa4edfb3c
+  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 256b940a1c5273be6ea8930b511feb0a3fb065f8
 

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DynamicLinks' do |dynamiclinks|
     # This will bundle in Firebase Dynamic Link support
-    dynamiclinks.dependency 'Firebase/DynamicLinks', '~4.0'
+    dynamiclinks.dependency 'Firebase/DynamicLinks', '~>4.0'
   end
 end

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DynamicLinks' do |dynamiclinks|
     # This will bundle in Firebase Dynamic Link support
-    dynamiclinks.dependency 'Firebase/DynamicLinks'
+    dynamiclinks.dependency 'Firebase/DynamicLinks', '~4.0'
   end
 end

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DynamicLinks' do |dynamiclinks|
     # This will bundle in Firebase Dynamic Link support
-    dynamiclinks.dependency 'Firebase/DynamicLinks', '~>4.0'
+    dynamiclinks.dependency 'Firebase/DynamicLinks', '~> 4.0'
   end
 end

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DynamicLinks' do |dynamiclinks|
     # This will bundle in Firebase Dynamic Link support
-    dynamiclinks.dependency 'Firebase/DynamicLinks', '~> 4.0'
+    dynamiclinks.dependency 'Firebase/DynamicLinks'
   end
 end

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'Analytics', '~> 3.2'
-  s.dependency 'Firebase/Core', '~> 4.0'
+  s.dependency 'Firebase/Core', '~> 5.0'
 
   s.subspec 'Core' do |core|
     #For users who only want the core Firebase package
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DynamicLinks' do |dynamiclinks|
     # This will bundle in Firebase Dynamic Link support
-    dynamiclinks.dependency 'Firebase/DynamicLinks', '~> 4.0'
+    dynamiclinks.dependency 'Firebase/DynamicLinks'
   end
 end


### PR DESCRIPTION
Updated to Firebase 5 to support Crashlytics for Traveloka:
https://segment.atlassian.net/secure/RapidBoard.jspa?rapidView=116&modal=detail&selectedIssue=ENT-151