### PR TITLE
Add promotion viewed event

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -306,6 +306,30 @@ describe(@"Firebase Integration", ^{
         }];
     });
 
+    it(@"track Promotion Viewed", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Promotion Viewed"
+            properties:@{
+                @"product_id" : @"507f1f77bcf86cd799439011",
+                @"category" : @"Games",
+                @"name" : @"Monopoly 3rd Edition",
+                @"price" : @18.99,
+                @"quantity" : @1,
+                @"currency" : @"usd",
+            }
+            context:@{}
+            integrations:@{}];
+
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"present_offer" parameters:@{
+            @"item_id" : @"507f1f77bcf86cd799439011",
+            @"item_category" : @"Games",
+            @"item_name" : @"Monopoly 3rd Edition",
+            @"price" : @18.99,
+            @"quantity" : @1,
+            @"currency" : @"usd",
+        }];
+    });
+
     it(@"track Payment Info Entered", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Payment Info Entered"
             properties:@{

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -76,6 +76,7 @@
                                              kFIREventAddToCart, @"Product Added",
                                              kFIREventRemoveFromCart, @"Product Removed",
                                              kFIREventBeginCheckout, @"Checkout Started",
+                                             kFIREventPresentOffer, @"Promotion Viewed",
                                              kFIREventAddPaymentInfo, @"Payment Info Entered",
                                              kFIREventEcommercePurchase, @"Order Completed",
                                              kFIREventPurchaseRefund, @"Order Refunded",


### PR DESCRIPTION
Description:
The mapping for the Promotion viewed event is currently not tracked, despite listed in the docs:
https://segment.com/docs/destinations/firebase/#event-mappings

Pr to track kFIREventPresentOffer
https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#/c:FIREventNames.h@kFIREventPresentOffer