### PR TITLE
Add support for screen calls explicitly

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -65,7 +65,7 @@ describe(@"Firebase Integration", ^{
             @"Starship_Type" : @"Death Star"
         }];
     });
-    
+
     it(@"track with event name and parmas separated by periods", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Starship.Ordered"
                                                                properties:@{
@@ -73,13 +73,13 @@ describe(@"Firebase Integration", ^{
                                                                             }
                                                                   context:@{}
                                                              integrations:@{}];
-        
+
         [integration track:payload];
         [verify(mockFirebase) logEventWithName:@"Starship_Ordered" parameters:@{
                                                                                 @"Starship_Type" : @"Death Star"
                                                                                 }];
     });
-    
+
     it(@"track with leading and trailing spacing for event name", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"   Starship Ordered  "
                                                                properties:@{
@@ -87,7 +87,7 @@ describe(@"Firebase Integration", ^{
                                                                             }
                                                                   context:@{}
                                                              integrations:@{}];
-        
+
         [integration track:payload];
         [verify(mockFirebase) logEventWithName:@"Starship_Ordered" parameters:@{
                                                                                 @"Starship_Type" : @"Death Star"
@@ -553,6 +553,15 @@ describe(@"Firebase Integration", ^{
         [verify(mockFirebase) logEventWithName:@"search" parameters:@{
             @"search_term" : @"blue hotpants"
         }];
+    });
+
+    it(@"track screen with name", ^{
+        SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Home screen"
+                                                                properties:@{}
+                                                                   context:@{}
+                                                              integrations:@{}];
+        [integration screen:payload];
+        [verify(mockFirebase) setScreenName:@"Home screen" screenClass:nil];
     });
 
 });

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -64,6 +64,13 @@
 }
 
 
+- (void)screen:(SEGScreenPayload *)payload
+{
+    [self.firebaseClass setScreenName:payload.name screenClass:nil];
+    SEGLog(@"[FIRAnalytics setScreenName:%@]", payload.name);
+}
+
+
 #pragma mark - Utilities
 
 // Event names can be up to 32 characters long, may only contain alphanumeric


### PR DESCRIPTION
I am releasing this PR for customer: https://github.com/segmentio/analytics-ios-integrations/pull/11/files

"Segment’s documentation mentions that screen events are not passed through to the Firebase SDK because Firebase does automatic screen tracking. (https://segment.com/docs/connections/destinations/catalog/firebase/#screen)
However, it mentions that Automatic+Manual screen tracking should be supported, but this currently does not work because Segment does not forward the manual screen tracking events.

This change will allow explicitly tracked screens in analytics-react-native using analytics.screen to actually be tracked in Firebase"