### PR TITLE
Add mapping for products array

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -142,7 +142,7 @@ describe(@"Firebase Integration", ^{
             @"tax" : @1.20,
             @"currency" : @"USD",
             @"item_category" : @"Games",
-            @"products" : @{
+            @"items" : @{
                 @"product_id" : @"2013294",
                 @"category" : @"Games",
                 @"name" : @"Monopoly: 3rd Edition",
@@ -337,7 +337,7 @@ describe(@"Firebase Integration", ^{
             @"tax" : @1.20,
             @"currency" : @"USD",
             @"item_category" : @"Games",
-            @"products" : @{
+            @"items" : @{
                 @"product_id" : @"2013294",
                 @"category" : @"Games",
                 @"name" : @"Monopoly: 3rd Edition",
@@ -430,7 +430,7 @@ describe(@"Firebase Integration", ^{
         [verify(mockFirebase) logEventWithName:@"view_item_list" parameters:@{
             @"list_id" : @"hot_deals_1",
             @"item_category" : @"Deals",
-            @"products" : @{
+            @"items" : @{
                 @"product_id" : @"2013294",
                 @"category" : @"Games",
                 @"name" : @"Monopoly: 3rd Edition",

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -136,6 +136,7 @@
     NSDictionary *map = [NSDictionary dictionaryWithObjectsAndKeys:
                                           kFIRParameterItemCategory, @"category",
                                           kFIRParameterItemID, @"product_id",
+                                          kFIRParameterItems, @"products",
                                           kFIRParameterItemName, @"name",
                                           kFIRParameterPrice, @"price",
                                           kFIRParameterQuantity, @"quantity",


### PR DESCRIPTION
For firebase events products should be mapped to parameter called items: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#kfirparameteritems

Not mapping this will result in the evnet being rejected. 