### PR TITLE
Add Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,12 @@ Carthage
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
+Carthage/
 Pods/
 .clang-format
+IDEWorkspaceChecks.plist
+/Segment-Firebase.xcodeproj/project.xcworkspace/contents.xcworkspacedata

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "segmentio/analytics-ios"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 6.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.29.0"
+github "segmentio/analytics-ios" "4.0.4"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace 
 install: Example/Podfile $(PROJECT).podspec
 	pod repo update
 	pod install --project-directory=Example
+	carthage bootstrap --platform ios --use-ssh
 
 lint:
 	pod lib lint --use-libraries --allow-warnings

--- a/Segment-Firebase.xcodeproj/project.pbxproj
+++ b/Segment-Firebase.xcodeproj/project.pbxproj
@@ -1,0 +1,433 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F456135D24D52C49002B0185 /* Analytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7C24D2686F0002845C /* Analytics.framework */; };
+		F456135E24D52C49002B0185 /* FIRAnalyticsConnector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7424D2686F0002845C /* FIRAnalyticsConnector.framework */; };
+		F456136024D52C49002B0185 /* FirebaseAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7624D2686F0002845C /* FirebaseAnalytics.framework */; };
+		F456136124D52C49002B0185 /* FirebaseCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7724D2686F0002845C /* FirebaseCore.framework */; };
+		F456136224D52C49002B0185 /* FirebaseCoreDiagnostics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7D24D2686F0002845C /* FirebaseCoreDiagnostics.framework */; };
+		F456136324D52C49002B0185 /* FirebaseInstallations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7324D2686F0002845C /* FirebaseInstallations.framework */; };
+		F456136424D52C49002B0185 /* GoogleAppMeasurement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7524D2686F0002845C /* GoogleAppMeasurement.framework */; };
+		F456136524D52C49002B0185 /* GoogleDataTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7924D2686F0002845C /* GoogleDataTransport.framework */; };
+		F456136624D52C49002B0185 /* GoogleUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7E24D2686F0002845C /* GoogleUtilities.framework */; };
+		F456136724D52C49002B0185 /* nanopb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7A24D2686F0002845C /* nanopb.framework */; };
+		F456136824D52C49002B0185 /* PromisesObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4AA1F7B24D2686F0002845C /* PromisesObjC.framework */; };
+		F456136924D52F45002B0185 /* SEGFirebaseIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = F4AA1F4B24D263BF0002845C /* SEGFirebaseIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F456136A24D52F45002B0185 /* SEGFirebaseIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = F4AA1F4F24D263BF0002845C /* SEGFirebaseIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4AA1F5424D263BF0002845C /* SEGFirebaseIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = F4AA1F4D24D263BF0002845C /* SEGFirebaseIntegrationFactory.m */; };
+		F4AA1F5524D263BF0002845C /* SEGFirebaseIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = F4AA1F4E24D263BF0002845C /* SEGFirebaseIntegration.m */; };
+		F4AA1F7024D264570002845C /* Segment_Firebase.h in Headers */ = {isa = PBXBuildFile; fileRef = F4AA1F6E24D264570002845C /* Segment_Firebase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F4AA1F3E24D263820002845C /* Segment_Firebase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Segment_Firebase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4AA1F4B24D263BF0002845C /* SEGFirebaseIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGFirebaseIntegration.h; sourceTree = "<group>"; };
+		F4AA1F4D24D263BF0002845C /* SEGFirebaseIntegrationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGFirebaseIntegrationFactory.m; sourceTree = "<group>"; };
+		F4AA1F4E24D263BF0002845C /* SEGFirebaseIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGFirebaseIntegration.m; sourceTree = "<group>"; };
+		F4AA1F4F24D263BF0002845C /* SEGFirebaseIntegrationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGFirebaseIntegrationFactory.h; sourceTree = "<group>"; };
+		F4AA1F6E24D264570002845C /* Segment_Firebase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Segment_Firebase.h; sourceTree = "<group>"; };
+		F4AA1F6F24D264570002845C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F4AA1F7324D2686F0002845C /* FirebaseInstallations.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseInstallations.framework; path = Carthage/Build/iOS/FirebaseInstallations.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7424D2686F0002845C /* FIRAnalyticsConnector.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FIRAnalyticsConnector.framework; path = Carthage/Build/iOS/FIRAnalyticsConnector.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7524D2686F0002845C /* GoogleAppMeasurement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppMeasurement.framework; path = Carthage/Build/iOS/GoogleAppMeasurement.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7624D2686F0002845C /* FirebaseAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseAnalytics.framework; path = Carthage/Build/iOS/FirebaseAnalytics.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7724D2686F0002845C /* FirebaseCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCore.framework; path = Carthage/Build/iOS/FirebaseCore.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7824D2686F0002845C /* Firebase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Firebase.framework; path = Carthage/Build/iOS/Firebase.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7924D2686F0002845C /* GoogleDataTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleDataTransport.framework; path = Carthage/Build/iOS/GoogleDataTransport.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7A24D2686F0002845C /* nanopb.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = nanopb.framework; path = Carthage/Build/iOS/nanopb.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7B24D2686F0002845C /* PromisesObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromisesObjC.framework; path = Carthage/Build/iOS/PromisesObjC.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7C24D2686F0002845C /* Analytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Analytics.framework; path = Carthage/Build/iOS/Analytics.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7D24D2686F0002845C /* FirebaseCoreDiagnostics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCoreDiagnostics.framework; path = Carthage/Build/iOS/FirebaseCoreDiagnostics.framework; sourceTree = SOURCE_ROOT; };
+		F4AA1F7E24D2686F0002845C /* GoogleUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleUtilities.framework; path = Carthage/Build/iOS/GoogleUtilities.framework; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F4AA1F3B24D263820002845C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F456135D24D52C49002B0185 /* Analytics.framework in Frameworks */,
+				F456135E24D52C49002B0185 /* FIRAnalyticsConnector.framework in Frameworks */,
+				F456136024D52C49002B0185 /* FirebaseAnalytics.framework in Frameworks */,
+				F456136124D52C49002B0185 /* FirebaseCore.framework in Frameworks */,
+				F456136224D52C49002B0185 /* FirebaseCoreDiagnostics.framework in Frameworks */,
+				F456136324D52C49002B0185 /* FirebaseInstallations.framework in Frameworks */,
+				F456136424D52C49002B0185 /* GoogleAppMeasurement.framework in Frameworks */,
+				F456136524D52C49002B0185 /* GoogleDataTransport.framework in Frameworks */,
+				F456136624D52C49002B0185 /* GoogleUtilities.framework in Frameworks */,
+				F456136724D52C49002B0185 /* nanopb.framework in Frameworks */,
+				F456136824D52C49002B0185 /* PromisesObjC.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F4AA1F3424D263820002845C = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F7224D268430002845C /* Frameworks */,
+				F4AA1F4924D263BF0002845C /* Segment-Firebase */,
+				F4AA1F3F24D263820002845C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F4AA1F3F24D263820002845C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F3E24D263820002845C /* Segment_Firebase.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F4AA1F4924D263BF0002845C /* Segment-Firebase */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F6D24D264570002845C /* Resources */,
+				F4AA1F4A24D263BF0002845C /* Classes */,
+			);
+			path = "Segment-Firebase";
+			sourceTree = "<group>";
+		};
+		F4AA1F4A24D263BF0002845C /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F4B24D263BF0002845C /* SEGFirebaseIntegration.h */,
+				F4AA1F4D24D263BF0002845C /* SEGFirebaseIntegrationFactory.m */,
+				F4AA1F4E24D263BF0002845C /* SEGFirebaseIntegration.m */,
+				F4AA1F4F24D263BF0002845C /* SEGFirebaseIntegrationFactory.h */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		F4AA1F6D24D264570002845C /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F6E24D264570002845C /* Segment_Firebase.h */,
+				F4AA1F6F24D264570002845C /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		F4AA1F7224D268430002845C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA1F7C24D2686F0002845C /* Analytics.framework */,
+				F4AA1F7424D2686F0002845C /* FIRAnalyticsConnector.framework */,
+				F4AA1F7824D2686F0002845C /* Firebase.framework */,
+				F4AA1F7624D2686F0002845C /* FirebaseAnalytics.framework */,
+				F4AA1F7724D2686F0002845C /* FirebaseCore.framework */,
+				F4AA1F7D24D2686F0002845C /* FirebaseCoreDiagnostics.framework */,
+				F4AA1F7324D2686F0002845C /* FirebaseInstallations.framework */,
+				F4AA1F7524D2686F0002845C /* GoogleAppMeasurement.framework */,
+				F4AA1F7924D2686F0002845C /* GoogleDataTransport.framework */,
+				F4AA1F7E24D2686F0002845C /* GoogleUtilities.framework */,
+				F4AA1F7A24D2686F0002845C /* nanopb.framework */,
+				F4AA1F7B24D2686F0002845C /* PromisesObjC.framework */,
+			);
+			path = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		F4AA1F3924D263820002845C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4AA1F7024D264570002845C /* Segment_Firebase.h in Headers */,
+				F456136924D52F45002B0185 /* SEGFirebaseIntegration.h in Headers */,
+				F456136A24D52F45002B0185 /* SEGFirebaseIntegrationFactory.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		F4AA1F3D24D263820002845C /* Segment-Firebase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4AA1F4624D263820002845C /* Build configuration list for PBXNativeTarget "Segment-Firebase" */;
+			buildPhases = (
+				F4AA1F3924D263820002845C /* Headers */,
+				F4AA1F3A24D263820002845C /* Sources */,
+				F4AA1F3B24D263820002845C /* Frameworks */,
+				F4AA1F3C24D263820002845C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Segment-Firebase";
+			productName = "Segment-FirebaseA";
+			productReference = F4AA1F3E24D263820002845C /* Segment_Firebase.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F4AA1F3524D263820002845C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1160;
+				ORGANIZATIONNAME = Mapbox;
+				TargetAttributes = {
+					F4AA1F3D24D263820002845C = {
+						CreatedOnToolsVersion = 11.6;
+					};
+				};
+			};
+			buildConfigurationList = F4AA1F3824D263820002845C /* Build configuration list for PBXProject "Segment-Firebase" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F4AA1F3424D263820002845C;
+			productRefGroup = F4AA1F3F24D263820002845C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F4AA1F3D24D263820002845C /* Segment-Firebase */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F4AA1F3C24D263820002845C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F4AA1F3A24D263820002845C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4AA1F5424D263BF0002845C /* SEGFirebaseIntegrationFactory.m in Sources */,
+				F4AA1F5524D263BF0002845C /* SEGFirebaseIntegration.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F4AA1F4424D263820002845C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F4AA1F4524D263820002845C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F4AA1F4724D263820002845C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Segment-Firebase/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dane.miluski.Segment-Firebase";
+				PRODUCT_NAME = Segment_Firebase;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F4AA1F4824D263820002845C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Segment-Firebase/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dane.miluski.Segment-Firebase";
+				PRODUCT_NAME = Segment_Firebase;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F4AA1F3824D263820002845C /* Build configuration list for PBXProject "Segment-Firebase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4AA1F4424D263820002845C /* Debug */,
+				F4AA1F4524D263820002845C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F4AA1F4624D263820002845C /* Build configuration list for PBXNativeTarget "Segment-Firebase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4AA1F4724D263820002845C /* Debug */,
+				F4AA1F4824D263820002845C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F4AA1F3524D263820002845C /* Project object */;
+}

--- a/Segment-Firebase.xcodeproj/xcshareddata/xcschemes/Segment-Firebase.xcscheme
+++ b/Segment-Firebase.xcodeproj/xcshareddata/xcschemes/Segment-Firebase.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4AA1F3D24D263820002845C"
+               BuildableName = "Segment_Firebase.framework"
+               BlueprintName = "Segment-Firebase"
+               ReferencedContainer = "container:Segment-Firebase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4AA1F3D24D263820002845C"
+            BuildableName = "Segment_Firebase.framework"
+            BlueprintName = "Segment-Firebase"
+            ReferencedContainer = "container:Segment-Firebase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Segment-Firebase/Resources/Info.plist
+++ b/Segment-Firebase/Resources/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Segment-Firebase/Resources/Segment_Firebase.h
+++ b/Segment-Firebase/Resources/Segment_Firebase.h
@@ -1,0 +1,19 @@
+//
+//  Segment_Firebase.h
+//  Segment-Firebase
+//
+//  Created by Dane Miluski on 7/29/20.
+//  Copyright © 2020 Mapbox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Segment_Firebase.
+FOUNDATION_EXPORT double Segment_FirebaseVersionNumber;
+
+//! Project version string for Segment_Firebase.
+FOUNDATION_EXPORT const unsigned char Segment_FirebaseVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Segment_Firebase/PublicHeader.h>
+#import <Segment_Firebase/SEGFirebaseIntegration.h>
+#import <Segment_Firebase/SEGFirebaseIntegrationFactory.h>


### PR DESCRIPTION
Issue:
[Issue-35 Only able to be installed via cocoapods](https://github.com/segment-integrations/analytics-ios-integration-firebase/issues/35)

Problem:
Existing Firebase integrations do not support Carthage

Approach:
Including packaging project -> framework which can be consumed by developers

There's likely a better approach given Firebase guidelines, but this allowed be to build and link with firebase + integrations with carthage via 

Cartfile:
```
github "dmiluski/analytics-ios-integration-intercom" "carthage-support"
```

`carthage bootstrap --platform ios --use-ssh --cache-builds`


Changes:
+ Include Cartfile
+ Include Packaging Project
- Ignore unnecessary files
+ Expose headers
+ Share scheme