### PR TITLE
Truncate names to 40 characters

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -66,6 +66,20 @@ describe(@"Firebase Integration", ^{
         }];
     });
 
+    it(@"track with event name and prop name > 40 chars", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"ufddxsblvtujywadkmohvddqnpbginxozqjffhjyy"
+            properties:@{
+                @"ufddxsblvtujywadkmohvddqnpbginxozqjffhjyy" : @"Death Star"
+            }
+            context:@{}
+            integrations:@{}];
+
+        [integration track:payload];
+        [verify(mockFirebase) logEventWithName:@"ufddxsblvtujywadkmohvddqnpbginxozqjffhjy" parameters:@{
+            @"ufddxsblvtujywadkmohvddqnpbginxozqjffhjy" : @"Death Star"
+        }];
+    });
+
     it(@"track with event name and parmas separated by periods", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Starship.Ordered"
                                                                properties:@{
@@ -575,7 +589,7 @@ describe(@"Firebase Integration", ^{
                                                                    context:@{}
                                                               integrations:@{}];
         [integration screen:payload];
-        [verify(mockFirebase) setScreenName:@"Home screen" screenClass:nil];
+        [verify(mockFirebase) setScreenName:@"Home_screen" screenClass:nil];
     });
 
 });

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -66,16 +66,38 @@
 
 - (void)screen:(SEGScreenPayload *)payload
 {
-    [self.firebaseClass setScreenName:payload.name screenClass:nil];
+    NSString *name = [SEGFirebaseIntegration formatFirebaseNameString:payload.name];
+
+    [self.firebaseClass setScreenName:name screenClass:nil];
     SEGLog(@"[FIRAnalytics setScreenName:%@]", payload.name);
 }
 
 
 #pragma mark - Utilities
 
-// Event names can be up to 32 characters long, may only contain alphanumeric
-// characters and underscores ("_"), and must start with an alphabetic character. The "firebase_"
-// prefix is reserved and should not be used.
+// Formats the following types of strings to match the Firebase requirements:
+//
+// Event Names: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#+logeventwithname:parameters:
+// Should contain 1 to 40 alphanumeric characters or underscores.
+//
+// Parameter Names: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#/c:objc(cs)FIRAnalytics(cm)logEventWithName:parameters:
+// Should contain 1 to 40 alphanumeric characters or underscores.
+//
+// Screen Names: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#setscreennamescreenclass
+// Should contain 1 to 40 alphanumeric characters or underscores.
+
++ (NSString *)formatFirebaseNameString:(NSString *)name
+{
+    NSError *error = nil;
+
+    NSString *trimmed = [name stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"([^a-zA-Z0-9_])" options:0 error:&error];
+    NSString *formatted = [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, [trimmed length]) withTemplate:@"_"];
+
+    NSLog(@"Output: %@", formatted); 
+    return [formatted substringToIndex:MIN(40, [formatted length])];
+}
+
 
 // Maps Segment Spec to Firebase Constants
 // https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#/c:FIRParameterNames.h@kFIRParameterCampaign
@@ -99,37 +121,19 @@
                                              kFIREventSearch, @"Products Searched", nil];
 
     NSString *mappedEvent = [mapper objectForKey:event];
-    NSArray *periodSeparatedEvent = [event componentsSeparatedByString:@"."];
-    NSString *regexString = @"^[a-zA-Z0-9_]+$";
-    NSError *error = NULL;
-    NSRegularExpression *regex =
-    [NSRegularExpression regularExpressionWithPattern:regexString
-                                              options:0
-                                                error:&error];
-    NSUInteger numberOfMatches = [regex numberOfMatchesInString:event
-                                                        options:0
-                                                          range:NSMakeRange(0, [event length])];
     if (mappedEvent) {
         return mappedEvent;
-    } else if (numberOfMatches == 0) {
-        NSString *trimmedEvent = [event stringByTrimmingCharactersInSet:
-                                  [NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        if ([periodSeparatedEvent count] > 1) {
-            return [trimmedEvent stringByReplacingOccurrencesOfString:@"." withString:@"_"];
-        } else {
-            return [[trimmedEvent stringByReplacingOccurrencesOfString:@" " withString:@"_"] stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
-        }
     } else {
-        return event;
+        return [SEGFirebaseIntegration formatFirebaseNameString:event];
     }
 }
 
 /// Params supply information that contextualize Events. You can associate up to 25 unique Params
 /// with each Event type. Some Params are suggested below for certain common Events, but you are
 /// not limited to these. You may supply extra Params for suggested Events or custom Params for
-/// Custom events. Param names can be up to 24 characters long, may only contain alphanumeric
+/// Custom events. Param names can be up to 40 characters long, may only contain alphanumeric
 /// characters and underscores ("_"), and must start with an alphabetic character. Param values can
-/// be up to 36 characters long. The "firebase_" prefix is reserved and should not be used.
+/// be up to 100 characters long. The "firebase_" prefix is reserved and should not be used.
 
 - (NSDictionary *)returnMappedFirebaseParameters:(NSDictionary *)properties
 {
@@ -170,14 +174,8 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
     NSMutableDictionary *output = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
         [output removeObjectForKey:key];
-        NSArray *periodSeparatedKey = [key componentsSeparatedByString:@"."];
-        NSString *trimmedKey = [key stringByTrimmingCharactersInSet:
-                                  [NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        if ([periodSeparatedKey count] > 1) {
-            key = [trimmedKey stringByReplacingOccurrencesOfString:@"." withString:@"_"];
-        } else {
-            key = [[trimmedKey stringByReplacingOccurrencesOfString:@" " withString:@"_"] stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
-        }
+        key = [SEGFirebaseIntegration formatFirebaseNameString:key];
+
         if ([data isKindOfClass:[NSNumber class]]) {
             data = [NSNumber numberWithDouble:[data doubleValue]];
             [output setObject:data forKey:key];


### PR DESCRIPTION
### Why

We were seeing some events being recorded for android but not for iOS, and it seems like the cause is a string length limit in Firebase. It looks like others are seeing this issue as well: #20

The Firebase [docs] specify a length limit of 40 characters for event names, event parameter names, and screen names:

> Should contain 1 to 40 alphanumeric characters or underscores.

It seems like this is already implemented in [analytics-android-integration-firebase]. 

### What
* adds shared method to format event names, param names, and screen names
* adds test coverage

[docs]: https://support.google.com/firebase/answer/9237506?hl=en
[analytics-android-integration-firebase]: https://github.com/segment-integrations/analytics-android-integration-firebase/blob/0063b9a345a96638d4a159e0e50dd4dc60e47278/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java#L215-L224