### PR TITLE
Remove NSLog from formatFirebaseNameString

### DIFF
--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -103,7 +103,6 @@
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"([^a-zA-Z0-9_])" options:0 error:&error];
     NSString *formatted = [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, [trimmed length]) withTemplate:@"_"];
 
-    NSLog(@"Output: %@", formatted); 
     return [formatted substringToIndex:MIN(40, [formatted length])];
 }
 


### PR DESCRIPTION
I'm currently getting numerous `Output:` messages in my Xcode console log due to an NSLog in `formatFirebaseNameString`.  

This PR simply removes the NSLog.