### PR TITLE
Fix: cannot build a project that uses a Swift Package Manager

### DIFF
--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -6,7 +6,7 @@
 #if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
 #else
-#import <Segment/Segment.h>
+@import Segment;
 #endif
 
 

--- a/Segment-Firebase/Classes/SEGFirebaseIntegrationFactory.h
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegrationFactory.h
@@ -3,7 +3,7 @@
 #if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
 #else
-#import <Segment/Segment.h>
+@import Segment;
 #endif
 
 


### PR DESCRIPTION
This PR solves https://github.com/segment-integrations/analytics-ios-integration-firebase/issues/84

It solves a build error when building a project in Xcode 12.5.1 with Segment and Segment-Firebase dependencies added via Swift Package Manager:

![Screenshot 2021-11-16 at 13 41 00](https://user-images.githubusercontent.com/1786612/141993800-6b575438-7347-4b74-b0e7-888d333de712.png)
![Screenshot 2021-11-16 at 13 37 29](https://user-images.githubusercontent.com/1786612/141993809-26035101-6687-4279-a233-2cbf32b3bed4.png)
 