### PR TITLE
fix: incorrect "quantity" properties type for Firebase ecommerce event

### DIFF
--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -201,12 +201,13 @@ NSDictionary *formatEventProperties(NSDictionary *dictionary)
         [output removeObjectForKey:key];
         key = [SEGFirebaseIntegration formatFirebaseNameString:key];
 
-        if ([data isKindOfClass:[NSNumber class]]) {
+        if ([key isEqualToString:kFIRParameterQuantity]) {
+            data = @([data integerValue]);
+        } else if ([data isKindOfClass:[NSNumber class]]) {
             data = [NSNumber numberWithDouble:[data doubleValue]];
-            [output setObject:data forKey:key];
-        } else {
-            [output setObject:data forKey:key];
         }
+
+        [output setObject:data forKey:key];
     }];
 
     return [output copy];


### PR DESCRIPTION
For `quantity` property, any type that is not an integer will appear as `0` in the Firebase console