### PR TITLE
Skip FIRApp configure when testing

### DIFF
--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -9,6 +9,17 @@
 @import Segment;
 #endif
 
+BOOL segFirebase_isUnitTesting()
+{
+    static dispatch_once_t pred = 0;
+    static BOOL _isUnitTesting = NO;
+    dispatch_once(&pred, ^{
+        NSDictionary *env = [NSProcessInfo processInfo].environment;
+        _isUnitTesting = (env[@"XCTestConfigurationFilePath"] != nil);
+    });
+    return _isUnitTesting;
+}
+
 
 @implementation SEGFirebaseIntegration
 
@@ -27,6 +38,11 @@
 
         if ([FIRApp defaultApp]) {
             SEGLog(@"[FIRApp Configure] already called, skipping");
+            return self;
+        }
+        
+        if(segFirebase_isUnitTesting()) {
+            SEGLog(@"[FIRApp Configure] unit testing, skipping");
             return self;
         }
 


### PR DESCRIPTION
I recently added the SEGFirebase integration to an app. It works great! but we are experiencing crashes during our tests that have been hard to come to a real conclusion about. 

Our app checks `[FIRApp defaultApp]` before calling `[FIRApp configure]` - just as your framework does. But we still run into crashes during initialization of the SEGFirebaseIntegration class. 

I wish I had more to demonstrate other than a screenshot.

We only receive this crash when we are running tests in CI on Bitrise and Xcode Cloud which is the reason this has been hard to get a stack trace or anything more valuable. 

What this PR does:

* Take a method from SEGUtils (your segment analytics framework) to check if the process is unit testing and modified it to fit in SEGFirebase framework. 
* Returns `self` early if unit testing. 

<img width="768" alt="Screenshot 2023-06-27 at 2 29 05 PM" src="https://github.com/segment-integrations/analytics-ios-integration-firebase/assets/2376591/59e59afe-3701-44e4-b6ff-72bb0db79e14">
